### PR TITLE
Make sure command is ran in a server. If not return a message to redirect the user to the right channel.

### DIFF
--- a/src/server/credits/farmCredits.js
+++ b/src/server/credits/farmCredits.js
@@ -1,19 +1,24 @@
 import { InteractionResponseType } from 'discord-interactions';
 import { JsonResponse } from '../responseTypes.js';
-import fetch from 'node-fetch';
 
 async function farmCredits(interaction, env, type = 'hourly') {
-  //const options = interaction.data.options;
-  // const local_url = 'http://127.0.0.1:8081/desktop-vision/us-central1/handleAPI/api/credits';
+  if (interaction.channel_type === 1) {
+    const dmResponse = {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: `Hello! To use this command please go to <#1162140966405284021>. If you haven't already, please make sure to link your Discord to your Desktop Vision account using /register.`,
+      },
+    };
+
+    return new JsonResponse(dmResponse);
+  }
+
+  const options = interaction.data.options;
+  const local_url =
+    'http://127.0.0.1:8081/desktop-vision/us-central1/handleAPI/api/credits';
   const url = 'https://desktop.vision/api/credits';
   const key = env.DV_KEY;
 
-  if (!interaction || !interaction.member || !interaction.member.user) {
-    return new JsonResponse({
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-      data: { content: 'You must be logged in to use this command.' },
-    });
-  }
   const response = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',

--- a/src/server/credits/farmCredits.js
+++ b/src/server/credits/farmCredits.js
@@ -2,6 +2,7 @@ import { InteractionResponseType } from 'discord-interactions';
 import { JsonResponse } from '../responseTypes.js';
 
 async function farmCredits(interaction, env, type = 'hourly') {
+  // Check if the interaction is in a DM (direct message)
   if (interaction.channel_type === 1) {
     const dmResponse = {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
@@ -13,11 +14,9 @@ async function farmCredits(interaction, env, type = 'hourly') {
     return new JsonResponse(dmResponse);
   }
 
-  const options = interaction.data.options;
-  const local_url =
-    'http://127.0.0.1:8081/desktop-vision/us-central1/handleAPI/api/credits';
+  const { DV_KEY } = env;
   const url = 'https://desktop.vision/api/credits';
-  const key = env.DV_KEY;
+  const key = DV_KEY;
 
   const response = await fetch(url, {
     headers: {

--- a/src/server/credits/farmCredits.js
+++ b/src/server/credits/farmCredits.js
@@ -1,45 +1,33 @@
 import { InteractionResponseType } from 'discord-interactions';
 import { JsonResponse } from '../responseTypes.js';
-import fetch from 'node-fetch';
 
-const REMOTE_URL = 'https://desktop.vision/api/credits/spin';
-
-async function spinCredits(interaction, env) {
-  const { DV_KEY } = env;
-  const { member, channel_type } = interaction;
-
+async function farmCredits(interaction, env, type = 'hourly') {
   // Check if the interaction is in a DM (direct message)
-  if (channel_type === 1) {
+  if (interaction.channel_type === 1) {
     const dmResponse = {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
-        content: 'This command is not available in DMs. Please use it in a server channel.',
+        content: `Hello! To use this command please go to <#1162140966405284021>. If you haven't already, please make sure to link your Discord to your Desktop Vision account using /register.`,
       },
     };
 
     return new JsonResponse(dmResponse);
   }
 
-  const response = await fetch(REMOTE_URL, {
+  const { DV_KEY } = env;
+  const url = 'https://desktop.vision/api/credits';
+  const key = DV_KEY;
+
+  const response = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',
-      'x-api-key': DV_KEY,
+      'x-api-key': key,
     },
     method: 'POST',
-    body: JSON.stringify({ discord_uid: member?.user?.id }), // Use optional chaining
+    body: JSON.stringify({ discord_uid: interaction.member.user.id, type }),
   });
 
   const body = await response.json();
-
-  if (body.credits === 0) {
-    const jsonResponseData = {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-      data: { content: 'You have no credits.' },
-      flags: 64,
-    };
-
-    return new JsonResponse(jsonResponseData);
-  }
 
   const finalEmbed = {
     description: body.message,
@@ -61,4 +49,4 @@ async function spinCredits(interaction, env) {
   return new JsonResponse(jsonResponseData);
 }
 
-export { spinCredits };
+export { farmCredits };

--- a/src/server/credits/spinCredits.js
+++ b/src/server/credits/spinCredits.js
@@ -6,10 +6,7 @@ const REMOTE_URL = 'https://desktop.vision/api/credits/spin';
 
 async function spinCredits(interaction, env) {
   const { DV_KEY } = env;
-  const {
-    member,
-    channel_type,
-  } = interaction;
+  const { member, channel_type } = interaction;
 
   // Check if the interaction is in a DM (direct message)
   if (channel_type === 1) {
@@ -33,16 +30,6 @@ async function spinCredits(interaction, env) {
   });
 
   const body = await response.json();
-
-  if (body.credits === 0) {
-    const jsonResponseData = {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-      data: { content: 'You have no credits.' },
-      flags: 64,
-    };
-
-    return new JsonResponse(jsonResponseData);
-  }
 
   const finalEmbed = {
     description: body.message,

--- a/src/server/credits/spinCredits.js
+++ b/src/server/credits/spinCredits.js
@@ -10,7 +10,19 @@ async function spinCredits(interaction, env) {
     member: {
       user: { id },
     },
+    channel_type,
   } = interaction;
+
+  if (channel_type === 1) {
+    const dmResponse = {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: 'This command is not available in DMs. Please use it in a server channel.',
+      },
+    };
+
+    return new JsonResponse(dmResponse);
+  }
 
   const response = await fetch(REMOTE_URL, {
     headers: {

--- a/src/server/credits/spinCredits.js
+++ b/src/server/credits/spinCredits.js
@@ -7,12 +7,11 @@ const REMOTE_URL = 'https://desktop.vision/api/credits/spin';
 async function spinCredits(interaction, env) {
   const { DV_KEY } = env;
   const {
-    member: {
-      user: { id },
-    },
+    member,
     channel_type,
   } = interaction;
 
+  // Check if the interaction is in a DM (direct message)
   if (channel_type === 1) {
     const dmResponse = {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
@@ -30,7 +29,7 @@ async function spinCredits(interaction, env) {
       'x-api-key': DV_KEY,
     },
     method: 'POST',
-    body: JSON.stringify({ discord_uid: id }),
+    body: JSON.stringify({ discord_uid: member?.user?.id }), // Use optional chaining
   });
 
   const body = await response.json();

--- a/src/server/register/registerUser.js
+++ b/src/server/register/registerUser.js
@@ -9,6 +9,18 @@ import { JsonResponse } from '../responseTypes.js';
  * @returns {Object} A JSON response.
  */
 async function registerUser(interaction, env) {
+  // Check if the interaction is in a DM (direct message)
+  if (interaction.channel_type === 1) {
+    const dmResponse = {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: `Hello! To use this command please go to <#1162140966405284021>. If you haven't already, please make sure to link your Discord to your Desktop Vision account using /register.`,
+      },
+    };
+
+    return new JsonResponse(dmResponse);
+  }
+
   // Get the user ID from the interaction
   const userId = interaction.member.user.id;
 


### PR DESCRIPTION
# Description

By using similar code on lines 11 to 16, I was able to add a check to handle the "error" when DMing the bot straight up. By using `interaction.channel_type === 1` (Discord's equiv of a DM channel), the bot handles DMs and responds with the following message: "`Hello! To use this command please go to <#1162140966405284021>. If you haven't already, please make sure to link your Discord to your Desktop Vision account using /register" where <#1162140966405284021> leads to the channel within the desktop vision discord server.

# What this changes

Before when we DMed the bot it would respond with: "You must be logged in to use this command.". Attempting to run /register would return with a "This interaction failed" error. Now running essentially any command in DMs send a message to redirect the user to correct channel.

# Possible issues

- Users can add the bot to their discord server and use the bot there (which is fine I believe)
- Users may also use this command in ANY channel on the discord server.

# Suggestions:

- Returning the message in a embed like running the actual commands in a channel.
- Limit the commands to the #credits channel.